### PR TITLE
Enable task artisan to be run twice in one flow

### DIFF
--- a/lib/capistrano/tasks/laravel.rake
+++ b/lib/capistrano/tasks/laravel.rake
@@ -131,6 +131,9 @@ namespace :laravel do
         execute :php, :artisan, command, *args.extras, fetch(:laravel_artisan_flags)
       end
     end
+    
+    # enable task artisan to be ran twice
+    Rake::Task['laravel:artisan'].reenable
   end
 
   desc 'Optimize the configuration'


### PR DESCRIPTION
Because of using `invoke` to call `laravel:artisan[:command_name]`,
we should make task `laravel:artisan` can be run twice and more in one flow.