### PR TITLE
Restricted “laravel:storage_link” to Laravel v5.3+.

### DIFF
--- a/lib/capistrano/tasks/laravel.rake
+++ b/lib/capistrano/tasks/laravel.rake
@@ -181,7 +181,7 @@ namespace :laravel do
 
   desc 'Create a symbolic link from "public/storage" to "storage/app/public."'
   task :storage_link do
-    next if fetch(:laravel_version) < 5
+    next if fetch(:laravel_version) <= 5.3
     Rake::Task['laravel:artisan'].invoke('storage:link')
   end
 


### PR DESCRIPTION
Fixes #26.