### PR TITLE
fixes upload_dotenv_file not running by default

### DIFF
--- a/lib/capistrano/tasks/laravel.rake
+++ b/lib/capistrano/tasks/laravel.rake
@@ -142,7 +142,7 @@ namespace :laravel do
 
   desc 'Upload dotenv file for release.'
   task :upload_dotenv_file do
-    next unless fetch(:laravel_upload_env_file_on_deploy)
+    next unless fetch(:laravel_upload_dotenv_file_on_deploy)
 
     # Dotenv was introduced in Laravel 5
     next if fetch(:laravel_version) < 5


### PR DESCRIPTION
Two different varable names should be the same. Otherwise upload_dotenv_file will not run by default.
laravel_upload_dotenv_file_on_deploy
laravel_upload_env_file_on_deploy