### PR TITLE
Remove optimize command for Laravel version 5.5+

### DIFF
--- a/lib/capistrano/tasks/laravel.rake
+++ b/lib/capistrano/tasks/laravel.rake
@@ -189,6 +189,7 @@ namespace :laravel do
 
   desc "Optimize the framework for better performance."
   task :optimize do
+    next if fetch(:laravel_version) >= 5.5
     Rake::Task["laravel:artisan"].invoke(:optimize, "--force")
   end
 


### PR DESCRIPTION
`php artisan optimize` is deprecated as of Laravel version 5.5. It no longer does anything.

https://laravel.com/docs/5.5/upgrade

Fixes #42.