### PR TITLE
Add queue restart task

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ set :laravel_artisan_flags, "--env=#{fetch(:stage)}"
 # Which roles to use for running migrations
 set :laravel_migration_roles, :all
 
+# Which roles to use for restart queue worker
+set :laravel_queue_roles, :all
+
 # The artisan flags to include on artisan commands by default when running migrations
 set :laravel_migration_artisan_flags, "--force --env=#{fetch(:stage)}"
 
@@ -141,6 +144,7 @@ before 'deploy:updated',  'deploy:set_permissions:acl'
 before 'composer:run',    'laravel:upload_dotenv_file'
 after  'composer:run',    'laravel:storage_link'
 after  'composer:run',    'laravel:optimize'
+after 'composer:run',     'laravel:restart_queue'
 ```
 
 #### Task Descriptions
@@ -182,6 +186,9 @@ invoke 'laravel:migrate'
 
 # Rollback the last database migration.
 invoke 'laravel:migrate_rollback'
+
+# Restart the queue worker
+invoke 'laravel:restart_queue'
 ```
 
 ## Development

--- a/lib/capistrano/tasks/laravel.rake
+++ b/lib/capistrano/tasks/laravel.rake
@@ -226,6 +226,18 @@ namespace :laravel do
     set(:laravel_roles, laravel_roles)
     set(:laravel_artisan_flags, laravel_artisan_flags)
   end
+  
+  desc "Restart the queue worker"
+	task :restart_queue do
+		laravel_roles = fetch(:laravel_roles)
+
+		set(:laravel_roles, fetch(:laravel_queue_roles))
+
+		Rake::Task["laravel:artisan"].invoke("queue:restart")
+
+		set(:laravel_roles, laravel_roles)
+	end
+
 
   before "deploy:starting", "laravel:resolve_linked_dirs"
   before "deploy:starting", "laravel:resolve_acl_paths"


### PR DESCRIPTION
As in [docs](https://laravel.com/docs/5.6/queues#queue-workers-and-deployment), you should restart the queue workers after every deploy.

Added this functionality, successfully tested on my company's production environment.