### PR TITLE
Avoid .env file upload on rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Tested RVM versions to `2.5`, `2.6`, and `2.7`.
 - Source files to reflect changes requested by rubocop.
+- `laravel:upload_dotenv_file` to run before `deploy:updated` instead of
+  `composer:run` to avoid issues with rollback.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Deploy Laravel applications with Capistrano v3.*
 
 ## Installation
 
-If managing your Capistrano deploy as a ruby project, add this line to your application's Gemfile:
+If managing your Capistrano deploy as a ruby project, add this line to your
+application's Gemfile:
 
 ```ruby
 gem 'capistrano', '~> 3.0.0'
@@ -25,7 +26,9 @@ gem install capistrano-laravel
 
 ## Setting up Capistrano
 
-After installing Capistrano, you can use it to initialize a skeleton configuration. To setup Capistrano, please follow the documentation provided on their website:
+After installing Capistrano, you can use it to initialize a skeleton
+configuration. To setup Capistrano, please follow the documentation
+provided on their website:
 
 http://capistranorb.com/documentation/getting-started/preparing-your-application/
 
@@ -130,7 +133,8 @@ set :laravel_5_acl_paths, [
 
 ### Tasks
 
-The following tasks are added to your deploy automagically when adding capistrano/laravel to your deploy.
+The following tasks are added to your deploy automagically when adding
+capistrano/laravel to your deploy.
 
 ```ruby
 before 'deploy:starting', 'laravel:resolve_linked_dirs'
@@ -186,9 +190,14 @@ invoke 'laravel:migrate_rollback'
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`rake spec` to run the tests. You can also run `bin/console` for an interactive
+prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To
+release a new version, update the version number in `version.rb`, and then run
+`bundle exec rake release`, which will create a git tag for the version, push
+git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ before 'deploy:starting', 'laravel:resolve_acl_paths'
 after  'deploy:starting', 'laravel:ensure_linked_dirs_exist'
 before 'deploy:updating', 'laravel:ensure_acl_paths_exist'
 before 'deploy:updated',  'deploy:set_permissions:acl'
-before 'composer:run',    'laravel:upload_dotenv_file'
+before 'deploy:updated',  'laravel:upload_dotenv_file'
 after  'composer:run',    'laravel:storage_link'
 after  'composer:run',    'laravel:optimize'
 ```

--- a/lib/capistrano/tasks/laravel.rake
+++ b/lib/capistrano/tasks/laravel.rake
@@ -254,7 +254,7 @@ namespace :laravel do
   after  'deploy:starting', 'laravel:ensure_linked_dirs_exist'
   after  'deploy:updating', 'laravel:ensure_acl_paths_exist'
   before 'deploy:updated',  'deploy:set_permissions:acl'
-  before 'composer:run',    'laravel:upload_dotenv_file'
+  before 'deploy:updated',  'laravel:upload_dotenv_file'
   after  'composer:run',    'laravel:storage_link'
   after  'composer:run',    'laravel:optimize'
 end


### PR DESCRIPTION
Due to v0.0.6 of capistrano/composer, composer is ran on rollback, and causes capistrano/laravel to try and push the .env file again, which can cause a major issue. This fix will change when the .env file is uploaded and remove its dependency on composer:run.