### PR TITLE
Add comment to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ invoke 'laravel:upload_dotenv_file'
 
 # Execute a provided artisan command.
 # Replace :command_name with the command to execute
+# e.g. 'laravel:artisan[list]'
 invoke 'laravel:artisan[:command_name]'
 
 # Create a cache file for faster configuration loading


### PR DESCRIPTION
Added comments to complement ambiguous task expressions.
Since this task expression conflicts with the standard optional argument expression in the CLI, a concrete example was added to the comment.

Check about standard cli usage syntax: http://docopt.org/